### PR TITLE
Add checkout of tagged rc2_subset version

### DIFF
--- a/process_rc2_subset.sh
+++ b/process_rc2_subset.sh
@@ -17,6 +17,8 @@ eups list -s | grep lsst_distrib
 cd /sdf/group/rubin/user/$USER/bootcamp_2023
 
 git clone https://github.com/lsst-dm/rc2_subset
+# Check out the weekly tagged version that matches the weekly pipelines version you set up:
+git checkout w.2023.15
 setup -j -r rc2_subset
 echo $RC2_SUBSET_DIR
 cd $RC2_SUBSET_DIR


### PR DESCRIPTION
We should make sure that users are always checking out the same tagged version of rc2_subset as the weekly pipelines version they have set up.